### PR TITLE
refactor: sync

### DIFF
--- a/vir_conto/charts/insights_workbook.json
+++ b/vir_conto/charts/insights_workbook.json
@@ -1,26 +1,30 @@
 [
- {
-  "charts": "[\n {\n  \"chart_type\": \"Number\",\n  \"name\": \"j0q2n0glst\",\n  \"query\": \"h7fsijb352\",\n  \"title\": \"_Adatcsomagok Sz\\u00e1ma\"\n }\n]",
-  "dashboards": "[]",
-  "data_backup": null,
-  "docstatus": 0,
-  "doctype": "Insights Workbook",
-  "modified": "2025-07-15 11:42:31.563205",
-  "name": 16,
-  "queries": "[\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"h7fsijb352\",\n  \"title\": \"_tabData Packet\"\n }\n]",
-  "read_only": false,
-  "title": "_SAJAT"
- },
- {
-  "charts": "[\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"96d0t6hpk7\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Haszon Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Bar\",\n  \"name\": \"a338jq8f0b\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Haszon Diagram\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"b7u7v4kjrk\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Vev\\u0151k Sz\\u00e1ma Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Bar\",\n  \"name\": \"bvd9cvftqi\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Vev\\u0151k Sz\\u00e1ma Diagram\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"d4a0gi22vm\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"l0im5njjll\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k \\u00c1tlag Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Row\",\n  \"name\": \"p55s2d3jc8\",\n  \"query\": \"n30oaj7dgh\",\n  \"title\": \"_\\u00c9rt\\u00e9kes\\u00edt\\u00e9s F\\u0151csoport Nett\\u00f3\"\n },\n {\n  \"chart_type\": \"Line\",\n  \"name\": \"2t4r84ssfc\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"Chart 9\"\n },\n {\n  \"chart_type\": \"Number\",\n  \"name\": \"8m1rvla5qd\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"This is a really long number chart\"\n }\n]",
-  "dashboards": "[\n {\n  \"name\": \"8l21k4vh8h\",\n  \"title\": \"Dashboard 1\"\n }\n]",
-  "data_backup": null,
-  "docstatus": 0,
-  "doctype": "Insights Workbook",
-  "modified": "2025-06-17 23:00:35.099364",
-  "name": 8,
-  "queries": "[\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"n30oaj7dgh\",\n  \"title\": \"_\\u00c9rt\\u00e9kes\\u00edt\\u00e9s \\u00d6sszes\\u00edt\\u0151 Adatok\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"6v6acq7fu8\",\n  \"title\": \"_Forgalom \\u00d6sszes\\u00edt\\u0151 Adatok\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"qgt84ma7ln\",\n  \"title\": \"tabvir_csop\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k Adatok\"\n }\n]",
-  "read_only": false,
-  "title": "_VIR"
- }
+  {
+    "charts": "[\n {\n  \"chart_type\": \"Number\",\n  \"name\": \"j0q2n0glst\",\n  \"query\": \"h7fsijb352\",\n  \"title\": \"_Adatcsomagok Sz\\u00e1ma\"\n }\n]",
+    "dashboards": "[]",
+    "data_backup": null,
+    "docstatus": 0,
+    "doctype": "Insights Workbook",
+    "modified": "2025-07-15 11:42:31.563205",
+    "name": 16,
+    "queries": "[\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"h7fsijb352\",\n  \"title\": \"_tabData Packet\"\n }\n]",
+    "read_only": false,
+    "title": "_SAJAT",
+    "is_default": 1,
+    "vir_id": "vir-sajat"
+  },
+  {
+    "charts": "[\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"96d0t6hpk7\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Haszon Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Bar\",\n  \"name\": \"a338jq8f0b\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Haszon Diagram\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"b7u7v4kjrk\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Vev\\u0151k Sz\\u00e1ma Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Bar\",\n  \"name\": \"bvd9cvftqi\",\n  \"query\": \"6v6acq7fu8\",\n  \"title\": \"_Vev\\u0151k Sz\\u00e1ma Diagram\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"d4a0gi22vm\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Table\",\n  \"name\": \"l0im5njjll\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k \\u00c1tlag Kimutat\\u00e1s\"\n },\n {\n  \"chart_type\": \"Row\",\n  \"name\": \"p55s2d3jc8\",\n  \"query\": \"n30oaj7dgh\",\n  \"title\": \"_\\u00c9rt\\u00e9kes\\u00edt\\u00e9s F\\u0151csoport Nett\\u00f3\"\n },\n {\n  \"chart_type\": \"Line\",\n  \"name\": \"2t4r84ssfc\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"Chart 9\"\n },\n {\n  \"chart_type\": \"Number\",\n  \"name\": \"8m1rvla5qd\",\n  \"query\": \"e199lomf7t\",\n  \"title\": \"This is a really long number chart\"\n }\n]",
+    "dashboards": "[\n {\n  \"name\": \"8l21k4vh8h\",\n  \"title\": \"Dashboard 1\"\n }\n]",
+    "data_backup": null,
+    "docstatus": 0,
+    "doctype": "Insights Workbook",
+    "modified": "2025-06-17 23:00:35.099364",
+    "name": 8,
+    "queries": "[\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"n30oaj7dgh\",\n  \"title\": \"_\\u00c9rt\\u00e9kes\\u00edt\\u00e9s \\u00d6sszes\\u00edt\\u0151 Adatok\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"6v6acq7fu8\",\n  \"title\": \"_Forgalom \\u00d6sszes\\u00edt\\u0151 Adatok\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"qgt84ma7ln\",\n  \"title\": \"tabvir_csop\"\n },\n {\n  \"is_builder_query\": 1,\n  \"is_native_query\": 0,\n  \"is_script_query\": 0,\n  \"name\": \"e199lomf7t\",\n  \"title\": \"_K\\u00e9szlet\\u00e9rt\\u00e9k Adatok\"\n }\n]",
+    "read_only": false,
+    "title": "_VIR",
+    "is_default": 1,
+    "vir_id": "vir-vir"
+  }
 ]

--- a/vir_conto/commands.py
+++ b/vir_conto/commands.py
@@ -32,21 +32,32 @@ def export_default_charts():
 	"""Method for exporting Insights Queries, Charts, Dashboards."""
 	app = "vir_conto"
 
-	default_workbooks = [
-		wb["name"]
-		for wb in frappe.get_all("Insights Workbook", fields=["name", "title"])
-		if wb["title"].startswith("_")
-	]
+	# Find workbooks by title pattern (starting with "_") or already marked as default
+	default_workbooks = frappe.get_all(
+		"Insights Workbook",
+		fields=[
+			"name",
+			"title",
+		],
+		filters={"is_default": True},
+	)
 
 	if len(default_workbooks) < 1:
 		print("No default workbook found")
 		return
 
+	# Generate vir_id and set is_default for workbooks that don't have them
+	for wb in default_workbooks:
+		workbook = frappe.get_doc("Insights Workbook", wb)
+		workbook.generate_vir_id()
+
+	default_workbook_names = [wb["name"] for wb in default_workbooks]
+
 	fixtures = [
-		{"dt": "Insights Workbook", "filters": [["name", "in", default_workbooks]]},
-		{"dt": "Insights Query v3", "filters": [["workbook", "in", default_workbooks]]},
-		{"dt": "Insights Chart v3", "filters": [["workbook", "in", default_workbooks]]},
-		{"dt": "Insights Dashboard v3", "filters": [["workbook", "in", default_workbooks]]},
+		{"dt": "Insights Workbook", "filters": [["name", "in", default_workbook_names]]},
+		{"dt": "Insights Query v3", "filters": [["workbook", "in", default_workbook_names]]},
+		{"dt": "Insights Chart v3", "filters": [["workbook", "in", default_workbook_names]]},
+		{"dt": "Insights Dashboard v3", "filters": [["workbook", "in", default_workbook_names]]},
 	]
 
 	for fixture in fixtures:

--- a/vir_conto/overrides/insights_workbook.py
+++ b/vir_conto/overrides/insights_workbook.py
@@ -1,12 +1,12 @@
 import frappe
 from frappe import _
-from frappe.core.doctype.user.user import User
 from insights.insights.doctype.insights_workbook.insights_workbook import InsightsWorkbook
 
 
 class CustomInsightsWorkbook(InsightsWorkbook):
 	def before_save(self):
 		self.check_default_title_schema()
+		# self.generate_vir_id_if_needed()
 		super().before_save()
 
 	def check_default_title_schema(self):
@@ -17,9 +17,23 @@ class CustomInsightsWorkbook(InsightsWorkbook):
 		# Only change title if user has none of the admin roles
 		if self.title.startswith("_") and user_roles.isdisjoint(admin_roles):
 			self.title = self.title.lstrip("_")
+			self.is_default = 0
 			frappe.msgprint(
 				_(
 					"Workbook creation with default title schema like (_Account) is not allowed. Workbook title renamed."
 				),
 				indicator="yellow",
 			)
+
+	def generate_vir_id(self):
+		"""Generate `vir_id` and set `is_default` for default workbooks"""
+		if not self.title.startswith("_"):
+			return
+
+		# Generate vir_id if not already set
+		if not self.vir_id:
+			title_clean = self.title.lstrip("_").lower().replace(" ", "_")
+			self.vir_id = f"vir-{title_clean}"
+
+		self.is_default = 1
+		self.save()

--- a/vir_conto/patches.txt
+++ b/vir_conto/patches.txt
@@ -4,3 +4,4 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+vir_conto.patches.add_workbook_custom_fields

--- a/vir_conto/patches/add_workbook_custom_fields.py
+++ b/vir_conto/patches/add_workbook_custom_fields.py
@@ -1,0 +1,46 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	custom_fields = {
+		"Insights Workbook": [
+			{
+				"fieldname": "is_default",
+				"fieldtype": "Check",
+				"label": "Is Default",
+				"default": 0,
+				"insert_after": "title",
+				"description": "Indicates if this workbook is a default vir_conto workbook",
+				"no_copy": 1,
+				"print_hide": 1,
+				"in_list_view": 1,
+				"in_standard_filter": 1,
+				"search_index": 1,
+			},
+			{
+				"fieldname": "vir_id",
+				"fieldtype": "Data",
+				"label": "Vir ID",
+				"unique": 1,
+				"read_only": 1,
+				"insert_after": "is_default",
+				"description": "Unique identifier for vir_conto workbook synchronization",
+				"no_copy": 1,
+				"print_hide": 1,
+				"search_index": 1,
+			},
+		]
+	}
+
+	create_custom_fields(custom_fields)
+
+	# Generate vir_id for workbooks
+	frappe.reload_doctype("Insights Workbook")
+	workbooks = frappe.db.get_list("Insights Workbook")
+	for wb in workbooks:
+		workbook = frappe.get_doc("Insights Workbook", wb)
+		workbook.generate_vir_id()
+	frappe.db.commit()
+
+	print("Successfully added is_default and vir_id custom fields to Insights Workbook")

--- a/vir_conto/patches/add_workbook_custom_fields.py
+++ b/vir_conto/patches/add_workbook_custom_fields.py
@@ -10,6 +10,7 @@ def execute():
 				"fieldtype": "Check",
 				"label": "Is Default",
 				"default": 0,
+				"read_only": 1,
 				"insert_after": "title",
 				"description": "Indicates if this workbook is a default vir_conto workbook",
 				"no_copy": 1,
@@ -29,6 +30,7 @@ def execute():
 				"no_copy": 1,
 				"print_hide": 1,
 				"search_index": 1,
+				"depends_on": "is_default",
 			},
 		]
 	}

--- a/vir_conto/patches/add_workbook_custom_fields.py
+++ b/vir_conto/patches/add_workbook_custom_fields.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
+from vir_conto.overrides.insights_workbook import CustomInsightsWorkbook
+
 
 def execute():
 	custom_fields = {
@@ -37,11 +39,11 @@ def execute():
 
 	create_custom_fields(custom_fields)
 
-	# Generate vir_id for workbooks
+	# Generate vir_id for default workbooks
 	frappe.reload_doctype("Insights Workbook")
 	workbooks = frappe.db.get_list("Insights Workbook")
 	for wb in workbooks:
-		workbook = frappe.get_doc("Insights Workbook", wb)
+		workbook: CustomInsightsWorkbook = frappe.get_doc("Insights Workbook", wb)
 		workbook.generate_vir_id()
 	frappe.db.commit()
 

--- a/vir_conto/util.py
+++ b/vir_conto/util.py
@@ -253,7 +253,7 @@ def import_charts(workbook_lookup, doctypes, logger):
 				try:
 					lookup = workbook_lookup.get(int(workbook_id))
 					if not lookup:
-						msg = f"No workbook mapping found for workbook_id: {workbook_id}, skipping old_doc: {old_doc.name}"
+						msg = f"No workbook mapping found for workbook_id: {workbook_id}, workbook_lookup: {workbook_lookup}"
 						logger.warning(msg)
 						if PRINT:
 							print(msg)

--- a/vir_conto/util.py
+++ b/vir_conto/util.py
@@ -1,3 +1,6 @@
+import os
+from typing import Any, Optional
+
 import frappe
 import frappe.hooks
 from frappe.modules.import_file import read_doc_from_file
@@ -5,6 +8,8 @@ from insights.insights.doctype.insights_chart_v3.insights_chart_v3 import Insigh
 from insights.insights.doctype.insights_dashboard_v3.insights_dashboard_v3 import InsightsDashboardv3
 from insights.insights.doctype.insights_query_v3.insights_query_v3 import InsightsQueryv3
 from insights.insights.doctype.insights_workbook.insights_workbook import InsightsWorkbook
+
+PRINT = True
 
 
 def get_frappe_version() -> str:
@@ -14,6 +19,59 @@ def get_frappe_version() -> str:
 	:return	str: Frappe version number in string.
 	"""
 	return frappe.hooks.app_version
+
+
+def load_documents_from_json(file_name: str, doctype_name: str, logger) -> list[Any] | None:
+	"""
+	Load and validate documents from a JSON file in the charts directory.
+
+	Args:
+	        file_name: Name of the JSON file (with or without .json extension)
+	        doctype_name: Name of the doctype for logging purposes
+	        logger: Logger instance for error reporting
+
+	Returns:
+	        List of Frappe documents or None if loading failed
+	"""
+	try:
+		path = frappe.get_app_path("vir_conto", "charts", file_name)
+
+		if not os.path.exists(path):
+			msg = f"{doctype_name} file not found: {path}"
+			logger.error(msg)
+			if PRINT:
+				print(msg)
+			return None
+
+		docs = read_doc_from_file(path)
+
+		if not docs:
+			msg = f"No {doctype_name} found in file"
+			logger.warning(msg)
+			if PRINT:
+				print(msg)
+			return None
+
+		if not isinstance(docs, list):
+			docs = [docs]
+
+		# Convert to Frappe documents
+		frappe_docs = [frappe.get_doc(doc) for doc in docs]
+
+		return frappe_docs
+
+	except OSError as e:
+		msg = f"File system error loading {doctype_name}: {str(e)}"
+		logger.error(msg)
+		if PRINT:
+			print(msg)
+		return None
+	except Exception as e:
+		msg = f"Unexpected error loading {doctype_name}: {str(e)}"
+		logger.exception(msg)
+		if PRINT:
+			print(msg)
+		return None
 
 
 def sync_default_charts():
@@ -42,48 +100,96 @@ def sync_default_charts():
 	logger = frappe.logger("import", allow_site=True, file_count=5, max_size=250000)
 	logger.setLevel("INFO")
 
-	path = frappe.get_app_path("vir_conto", "charts", "insights_workbook.json")
-
-	# 1. (OLD) Import old title and name of workbook from JSON
 	try:
-		docs = read_doc_from_file(path)
-	except OSError:
-		logger.exception(f"{path} missing", OSError)
-		return
+		# frappe.db.begin()
+
+		# Step 1: Load workbooks from `charts/insights_workbook.json`
+		import_workbooks = load_documents_from_json("insights_workbook.json", "workbooks", logger)
+		if not import_workbooks:
+			msg = "No workbooks found to import, aborting synchronization"
+			logger.error(msg)
+			if PRINT:
+				print(msg)
+			return False
+
+		# Step 2: Create new workbooks if not exist already
+		for import_workbook in import_workbooks:
+			if not frappe.db.exists("Insights Workbook", {"vir_id": import_workbook.vir_id}):
+				# Ensure the workbook is marked as default
+				import_workbook.is_default = 1
+				# If not creates a new
+				import_workbook.insert()
+
+		# Step 3: Get existing workbooks and create lookup table
+		workbook_lookup = _create_workbook_lookup(import_workbooks, logger)
+		if not workbook_lookup:
+			msg = "Failed to create workbook lookup table, aborting synchronization"
+			logger.error(msg)
+			if PRINT:
+				print(msg)
+			return False
+
+		# Step 4: Clean existing default records,
+		#  in case if a default chart no longer needed
+		doctypes = ["Insights Query v3", "Insights Chart v3", "Insights Dashboard v3"]
+		_clean_existing_records(workbook_lookup, doctypes, logger)
+
+		# Step 5: Import queries, charts, dashboards for each workbook
+		_import_charts(workbook_lookup, doctypes, logger)
+
 	except Exception as e:
-		logger.exception(f"Undefined error happened: {e}")
+		msg = f"Failed to sync default charts: {str(e)}"
+		logger.exception(msg)
+		if PRINT:
+			print(msg)
+		# frappe.db.rollback()
 		return
 
-	if not docs or len(docs) < 1:
-		logger.warning("No workbooks found")
-		return
+	# Commit all changes
+	frappe.db.commit()
 
-	if not isinstance(docs, list):
-		docs = [docs]
-	old_workbooks: list[InsightsWorkbook] = [frappe.get_doc(doc) for doc in docs]
 
-	# 2. Check if a default workbook exists
-	for old_workbook in old_workbooks:
-		if not frappe.db.exists("Insights Workbook", {"title": old_workbook.title}):
-			# If not creates a new
-			old_workbook.insert()
+def _create_workbook_lookup(import_workbooks, logger):
+	try:
+		# Step 3: Get the workbook ID's from the new system
+		new_workbooks = frappe.get_all(
+			"Insights Workbook", fields=["name", "title", "vir_id"], filters={"is_default": 1}
+		)
 
-	# 3. (NEW) Get all workbooks title and name
-	new_workbooks = [
-		wb
-		for wb in frappe.get_all("Insights Workbook", fields=["name", "title"])
-		if wb["title"].startswith("_")
-	]
+		# 4. Create lookup table for migrating queries, charts, dashboards
+		workbook_lookup = {}
+		for new_workbook in new_workbooks:
+			# Configure organization access
+			configure_workbook_access(new_workbook, logger)
 
-	# 4. Create lookup table for migrating queries, charts, dashboards
-	workbook_lookup = {}
-	for new_workbook in new_workbooks:
-		# Configure Organization Access
+			# Create lookup mapping using vir_id
+			for import_workbook in import_workbooks:
+				if import_workbook.vir_id == new_workbook.vir_id:
+					workbook_lookup[import_workbook.name] = {
+						"new_id": new_workbook.name,
+						"vir_id": import_workbook.vir_id,
+					}
+					break
+
+		return workbook_lookup
+
+	except Exception as e:
+		msg = f"Failed to create workbook lookup table: {str(e)}"
+		logger.exception(msg)
+		if PRINT:
+			print(msg)
+		# return None
+		frappe.throw("Failed to create workbook lookup table")
+
+
+def configure_workbook_access(workbook, logger):
+	"""Configure public access for a workbook."""
+	try:
 		from insights.utils import DocShare
 
 		public_docshare = DocShare.get_or_create_doc(
 			share_doctype="Insights Workbook",
-			share_name=new_workbook.name,
+			share_name=workbook.name,
 			everyone=1,
 		)
 		public_docshare.read = 1
@@ -91,51 +197,66 @@ def sync_default_charts():
 		public_docshare.notify_by_email = 0
 		public_docshare.save(ignore_permissions=True)
 
-		# Create lookup Table
-		for old_workbook in old_workbooks:
-			if old_workbook.title == new_workbook.title:
-				workbook_lookup[old_workbook.name] = {
-					"new_id": new_workbook.name,
-					"title": old_workbook.title,
-				}
-				break
+	except Exception as e:
+		logger.error(
+			f"Failed to configure access for workbook '{workbook.get('title', 'Unknown')}': {str(e)}"
+		)
+		# Don't raise - this is not critical for the main functionality
 
-	# 5. Clearing tables, in case if a default chart no longer needed
+
+def _clean_existing_records(workbook_lookup, doctypes, logger):
 	# This ensures that removed default charts won't remain in client database
-	doctypes = ["Insights Query v3", "Insights Chart v3", "Insights Dashboard v3"]
 	for dt in doctypes:
-		for _, value in workbook_lookup.items():
-			frappe.db.delete(dt, filters={"workbook": value["new_id"]})
-
-	# 6. Import the rest (queries, charts, dashboards)
-	for dt in doctypes:
-		path = frappe.get_app_path("vir_conto", "charts", frappe.scrub(dt) + ".json")
-		docs = []
 		try:
-			docs = read_doc_from_file(path)
-		except OSError:
-			logger.exception(f"{path} missing")
-			break
+			for _, value in workbook_lookup.items():
+				frappe.db.delete(dt, filters={"workbook": value["new_id"]})
 
-		if not docs or len(docs) < 1:
-			logger.warning(f"No {dt} found")
-			break
+		except Exception as e:
+			msg = f"Failed to clean existing records for {dt}: {str(e)}"
+			logger.error(msg)
+			if PRINT:
+				print(msg)
 
-		if not isinstance(docs, list):
-			docs = [docs]
-		for doc in docs:
-			old_doc: InsightsQueryv3 | InsightsChartv3 | InsightsDashboardv3 = frappe.get_doc(doc)
 
-			# 7. Update workbook name accordingly
-			workbook_id = old_doc.workbook
-
-			# Must be parsed to int otherwise fails to get key
-			lookup = workbook_lookup.get(int(workbook_id))
-			if not lookup:
-				logger.warning(
-					f"No workbook mapping found for title: {workbook_id}, skipping old_doc: {old_doc.name}"
-				)
+def _import_charts(workbook_lookup, doctypes, logger):
+	for dt in doctypes:
+		try:
+			# Load documents using the reusable function
+			docs = load_documents_from_json(frappe.scrub(dt) + ".json", dt, logger)
+			if not docs:
+				msg = f"No {dt} found, skipping"
+				logger.warning(msg)
+				if PRINT:
+					print(msg)
 				continue
 
-			old_doc.workbook = lookup["new_id"]
-			old_doc.insert(ignore_links=True, set_name=old_doc.name)
+			for doc in docs:
+				old_doc: InsightsQueryv3 | InsightsChartv3 | InsightsDashboardv3 = doc
+
+				# Update workbook name accordingly
+				workbook_id = old_doc.workbook
+
+				# Must be parsed to int otherwise fails to get key
+				try:
+					lookup = workbook_lookup.get(int(workbook_id))
+					if not lookup:
+						msg = f"No workbook mapping found for workbook_id: {workbook_id}, skipping old_doc: {old_doc.name}"
+						logger.warning(msg)
+						if PRINT:
+							print(msg)
+						continue
+
+					old_doc.workbook = lookup["new_id"]
+					old_doc.insert(ignore_links=True, set_name=old_doc.name)
+				except Exception as e:
+					msg = f"Failed to process {dt} document {old_doc.name}: {str(e)}"
+					logger.error(msg)
+					if PRINT:
+						print(msg)
+					continue
+
+		except Exception as e:
+			msg = f"Failed to import {dt}: {str(e)}"
+			logger.exception(msg)
+			print(msg)
+			continue


### PR DESCRIPTION
Refactor synchronization process:
 -  refactor: added custom fields (`is_default`, `vir_id`) for `Insights Workbook`. When comparing workbooks it uses `vir_id` instead of `title`.  0991018b2a5c52d0a4b48373f98c59d4ccbef666
 - feat: more performant code when creating `workbook_lookup` table. 2a479274ad625212da7c68d9861e574e55984cce
 - fix: unwanted workbooks now removed when updating default workbooks. ec645c01ef249741c2bf1381f434e065f9ff447a

Summary: more robust synchronization process.